### PR TITLE
Fix pagination at last page of planet list 17

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -267,7 +267,7 @@ body {
 
 .planet-view {
   display: grid;
-  grid-template-rows: 20% auto auto;
+  grid-template-rows: 20% auto 4.4rem;
   margin: 0 23%;
   padding: 2rem 0; }
   .planet-view__header {

--- a/src/sass/pages/_planet-view.scss
+++ b/src/sass/pages/_planet-view.scss
@@ -10,7 +10,7 @@
 
 .planet-view {
   display: grid;
-  grid-template-rows: 20% auto auto;
+  grid-template-rows: 20% auto 4.4rem;
   margin: 0 23%;
   padding: 2rem 0;
 


### PR DESCRIPTION
The last page of planet list now looks like the following:

![screen shot 2018-10-02 at 11 22 32 pm](https://user-images.githubusercontent.com/25688258/46351218-12f35400-c69a-11e8-9445-67a7b6851496.png)
